### PR TITLE
Declare "firebase" module for importing.

### DIFF
--- a/firebase.d.ts
+++ b/firebase.d.ts
@@ -291,3 +291,6 @@ declare namespace firebase {
   
 }
 
+declare module 'firebase' {
+    export = firebase;
+}


### PR DESCRIPTION
I had an issue using this type definition with webpack because it did not declare a `"firebase"` module.

Adding the lines in this PR (and also deleting the references to `promise`) allowed me to get this one working with typings + webpack.

Thanks for writing this definition file!
