### PR TITLE
Fix noImplicitAny error

### DIFF
--- a/firebase.d.ts
+++ b/firebase.d.ts
@@ -11,7 +11,7 @@ declare namespace firebase {
             TIMESTAMP,
         }
 
-        export function enableLogging(enable: boolean);
+        export function enableLogging(enable: boolean): void;
     }
 
 


### PR DESCRIPTION
`enableLogging` has an implicit return of `any`. Typing as `void` allows the type definition to be used with the `--noImplicitAny` flag.
