### PR TITLE
Explicit void return type on enableLogging

### DIFF
--- a/firebase.d.ts
+++ b/firebase.d.ts
@@ -11,7 +11,7 @@ declare namespace firebase {
             TIMESTAMP,
         }
 
-        export function enableLogging(enable: boolean);
+        export function enableLogging(enable: boolean):void;
     }
 
 


### PR DESCRIPTION
Resolves `tsc --noImplicitAny` error: `error TS7010: 'enableLogging', which lacks return-type annotation, implicitly has an 'any' return type.`